### PR TITLE
[xml] Add .opf to xml file extensions

### DIFF
--- a/src/xml/xml.contribution.ts
+++ b/src/xml/xml.contribution.ts
@@ -8,7 +8,7 @@ import { registerLanguage } from '../_.contribution';
 
 registerLanguage({
 	id: 'xml',
-	extensions: ['.xml', '.dtd', '.ascx', '.csproj', '.config', '.wxi', '.wxl', '.wxs', '.xaml', '.svg', '.svgz'],
+	extensions: ['.xml', '.dtd', '.ascx', '.csproj', '.config', '.wxi', '.wxl', '.wxs', '.xaml', '.svg', '.svgz', '.opf'],
 	firstLine: '(\\<\\?xml.*)|(\\<svg)|(\\<\\!doctype\\s+svg)',
 	aliases: ['XML', 'xml'],
 	mimetypes: ['text/xml', 'application/xml', 'application/xaml+xml', 'application/xml-dtd'],


### PR DESCRIPTION
Add support for [EPUB 3 .opf files](https://www.edrlab.org/epub/anatomy-of-an-epub-3-file/) as XML.